### PR TITLE
Fix contactEntity memory spike

### DIFF
--- a/GAMEENGINE/ENGINE/ECS/COMPONENTS/PhysicsComponent.cpp
+++ b/GAMEENGINE/ENGINE/ECS/COMPONENTS/PhysicsComponent.cpp
@@ -346,7 +346,7 @@ void PhysicsComponent::CreatePhysicsLuaBind(sol::state& lua, Registry& registry)
 
 			auto bx = (position.x * p2m) - scaleHalfWidth;
 			auto by = (position.y * p2m) - scaleHalfHeight;
-			b2Body_SetTransform(body, b2Vec2{ bx, by }, b2Rot(0.f));
+			b2Body_SetTransform(body, b2Vec2{ bx, by }, b2Rot{.c = 1.f, .s = 0.f } );
 		}
 	);
 }

--- a/GAMEENGINE/ENGINE/PHYSICS/ContactListener.cpp
+++ b/GAMEENGINE/ENGINE/PHYSICS/ContactListener.cpp
@@ -23,17 +23,11 @@ void ContactListener::BeginContact(b2WorldId myWorldId)
 
 		try
 		{
-			auto a_any = std::any_cast<ObjectData&>(a_data->userData);//Some error happens here
-			auto b_any = std::any_cast<ObjectData&>(b_data->userData);//Some error happens here
+			auto* a_any = std::any_cast<ObjectData>(&a_data->userData);
+			auto* b_any = std::any_cast<ObjectData>(&b_data->userData);
 
-			a_any.AddContact(b_any);
-			b_any.AddContact(a_any);
-
-			/*a_data->userData.reset();
-			a_data->userData = a_any;
-
-			b_data->userData.reset();
-			b_data->userData = b_any;*/
+			a_any->AddContact(b_any);
+			b_any->AddContact(a_any);
 
 			SetUserContacts(a_data, b_data);
 		}
@@ -62,27 +56,11 @@ void ContactListener::EndContact(b2WorldId myWorldId)
 
 		try
 		{
-			auto a_any = std::any_cast<ObjectData&>(a_data->userData);//Some error happens here
-			auto b_any = std::any_cast<ObjectData&>(b_data->userData);//Some error happens here
+			auto* a_any = std::any_cast<ObjectData>(&a_data->userData);
+			auto* b_any = std::any_cast<ObjectData>(&b_data->userData);
 
-			if (!a_any.RemoveContact(b_any))
-			{
-				// TODO: LOG ERROR
-				//LOG_ERROR("Failed to remove data.")
-			}
-
-			if (!b_any.RemoveContact(a_any))
-			{
-				// TODO: LOG ERROR
-				//LOG_ERROR("Failed to remove data.")
-			}
-
-			/*a_data->userData.reset();
-			a_data->userData = a_any;
-
-			b_data->userData.reset();
-			b_data->userData = b_any;*/
-
+			a_any->RemoveContact(b_any);
+			b_any->RemoveContact(a_any);
 		}
 		catch (const std::bad_any_cast& ex)
 		{

--- a/GAMEENGINE/ENGINE/PHYSICS/UserData.cpp
+++ b/GAMEENGINE/ENGINE/PHYSICS/UserData.cpp
@@ -1,11 +1,11 @@
 #include "UserData.h"
 
-bool ObjectData::AddContact(const ObjectData& objectData)
+bool ObjectData::AddContact(const ObjectData* objectData)
 {
     auto contactItr = std::find_if(
         contactEntities.begin(), contactEntities.end(),
-        [&](ObjectData& contactInfo) {
-            return contactInfo == objectData;
+        [&](const ObjectData* contactInfo) {
+            return *contactInfo == *objectData;
         }
     );
 
@@ -18,12 +18,12 @@ bool ObjectData::AddContact(const ObjectData& objectData)
     return true;
 }
 
-bool ObjectData::RemoveContact(const ObjectData& objectData)
+bool ObjectData::RemoveContact(const ObjectData* objectData)
 {
     auto contactItr = std::remove_if(
         contactEntities.begin(), contactEntities.end(),
-        [&](const ObjectData& contactInfo) {
-            return contactInfo == objectData;
+        [&](const ObjectData* contactInfo) {
+            return *contactInfo == *objectData;
         }
     );
 

--- a/GAMEENGINE/ENGINE/PHYSICS/UserData.h
+++ b/GAMEENGINE/ENGINE/PHYSICS/UserData.h
@@ -20,7 +20,13 @@ struct ObjectData
     std::vector<const ObjectData*> contactEntities;
 
     friend bool operator==(const ObjectData& a, const ObjectData& b);
+    [[nodiscard]] std::string to_string() const;
+
+private:
     bool AddContact(const ObjectData* objectData);
     bool RemoveContact(const ObjectData* objectData);
-    [[nodiscard]] std::string to_string() const;
+    
+    // The add/remove contact functions should never be called
+    // outside of the contact listener.
+    friend class ContactListener;
 };

--- a/GAMEENGINE/ENGINE/PHYSICS/UserData.h
+++ b/GAMEENGINE/ENGINE/PHYSICS/UserData.h
@@ -17,10 +17,10 @@ struct ObjectData
     std::string tag{ "" }, group{ "" };
     bool bCollider{ false }, bTrigger{ false };
     std::uint32_t entityID{};
-    std::vector<ObjectData> contactEntities;
+    std::vector<const ObjectData*> contactEntities;
 
     friend bool operator==(const ObjectData& a, const ObjectData& b);
-    bool AddContact(const ObjectData& objectData);
-    bool RemoveContact(const ObjectData& objectData);
+    bool AddContact(const ObjectData* objectData);
+    bool RemoveContact(const ObjectData* objectData);
     [[nodiscard]] std::string to_string() const;
 };


### PR DESCRIPTION
* Changed the way we hold onto contactEntities. Rather than holding onto a copy of the objectData, we now hold onto a const ObjectData*.
* This avoids all of the extra copying of the vectors causing possible memory spikes.