### PR TITLE
Created a body wrapper

### DIFF
--- a/GAMEENGINE/ENGINE/ECS/COMPONENTS/PhysicsComponent.h
+++ b/GAMEENGINE/ENGINE/ECS/COMPONENTS/PhysicsComponent.h
@@ -51,7 +51,7 @@ public:
     ~PhysicsComponent() = default;
 
     void Init(int windowWidth, int windowHeight);
-    b2BodyId getBodyID() const { return bodyId; }
+    b2BodyId getBodyID() const { return m_pBody ? m_pBody->bodyId : b2_nullBodyId; }
     glm::vec2 BodyPosition();
 
     const bool IsSensor() const;
@@ -60,7 +60,7 @@ public:
 
 private:
     b2WorldId worldId;
-    b2BodyId bodyId;
+    std::shared_ptr<BodyWrapper> m_pBody;
     b2ShapeId shapeId;
 
     std::shared_ptr<UserData> m_pUserData;

--- a/GAMEENGINE/ENGINE/PHYSICS/Box2DWrappers.h
+++ b/GAMEENGINE/ENGINE/PHYSICS/Box2DWrappers.h
@@ -5,6 +5,29 @@
 
 #include "../LOGGER/log.h"
 
+struct BodyWrapper
+{
+	b2BodyId bodyId{ b2_nullBodyId };
+	BodyWrapper(const b2BodyId& bId) : bodyId{ bId } {}
+};
+
+struct BodyDestroyer
+{
+	void operator()(BodyWrapper* body) const
+	{
+		if (b2Body_IsValid(body->bodyId))
+		{
+			b2DestroyBody(body->bodyId);
+			LOG_INFO("Body Destroyed!");
+		}
+	}
+};
+
+static std::shared_ptr<BodyWrapper> MakeSharedBody(b2WorldId worldId, b2BodyDef* bodyDef)
+{
+	return std::shared_ptr<BodyWrapper>(new BodyWrapper(b2CreateBody(worldId, bodyDef)), BodyDestroyer{});
+}
+
 class Box2DWrappers
 {
 public:


### PR DESCRIPTION
* Create a body wrapper so we can use a custom deleter with a shared ptr.
* That way, if there are more than one copies of the physics component due to entt or other means, it all refers to the same shared ptr.
* It will only call the destroy on the custom deleter if there are no other references to the shared ptr.