### PR TITLE
Move Sound to New Object

### DIFF
--- a/GAMEENGINE/ENGINE/ECS/COMPONENTS/OpenALSoundComponent.cpp
+++ b/GAMEENGINE/ENGINE/ECS/COMPONENTS/OpenALSoundComponent.cpp
@@ -1,109 +1,7 @@
 #include "OpenALSoundComponent.h"
-
-OpenALSoundComponent::OpenALSoundComponent()
-	: p_Pitch(1.f), p_Gain(1.f), p_Position{ 0,0,0 }, p_Velocity{ 0,0,0 }, p_LoopSound(false), p_Buffer(0)
-{
-	alGenSources(1, &p_Source);
-	alSourcef(p_Source, AL_PITCH, p_Pitch);
-	alSourcef(p_Source, AL_GAIN, p_Gain);
-	alSource3f(p_Source, AL_POSITION, p_Position[0], p_Position[1], p_Position[2]);
-	alSource3f(p_Source, AL_VELOCITY, p_Velocity[0], p_Velocity[1], p_Velocity[2]);
-	alSourcei(p_Source, AL_LOOPING, p_LoopSound);
-}
-
-OpenALSoundComponent::~OpenALSoundComponent()
-{
-	Stop();                         //=>UNCOMMENT THESE TO SEE THE ERROR!
-	alDeleteSources(1, &p_Source);  //=>UNCOMMENT THESE TO SEE THE ERROR!
-}
-
-void OpenALSoundComponent::Play(std::string name)
-{
-	auto& assetManager = MAIN_REGISTRY().GetAssetManager();
-	ALuint buffer_to_play = assetManager.GetSoundEffect(name);
-	if (buffer_to_play == 0)
-	{
-		LOG_WARN("Play sound effect is called but the buffer received is zero!");
-	}
-	if (buffer_to_play != p_Buffer)
-	{
-		Stop();
-		p_Buffer = buffer_to_play;
-		alSourcei(p_Source, AL_BUFFER, static_cast<ALint>(p_Buffer));
-	}
-
-	alSourcePlay(p_Source);
-}
-
-void OpenALSoundComponent::Stop()
-{
-	alSourceStop(p_Source);
-}
-
-void OpenALSoundComponent::Pause()
-{
-	alSourcePause(p_Source);
-}
-
-void OpenALSoundComponent::Resume()
-{
-	alSourcePlay(p_Source);
-}
-
-void OpenALSoundComponent::SetPitch(float pitch)
-{
-	p_Pitch = pitch;
-	alSourcef(p_Source, AL_PITCH, p_Pitch);
-}
-
-void OpenALSoundComponent::SetGain(float gain)
-{
-	p_Gain = gain;
-	alSourcef(p_Source, AL_GAIN, p_Gain);
-}
-
-void OpenALSoundComponent::SetPosition(float x, float y, float z)
-{
-	p_Position[0] = x;
-	p_Position[1] = y;
-	p_Position[2] = z;
-	alSource3f(p_Source, AL_POSITION, x, y, z);
-}
-
-void OpenALSoundComponent::SetVelocity(float x, float y, float z)
-{
-	p_Velocity[0] = x;
-	p_Velocity[1] = y;
-	p_Velocity[2] = z;
-	alSource3f(p_Source, AL_VELOCITY, x, y, z);
-}
-
-void OpenALSoundComponent::SetLooping(bool loop)
-{
-	p_LoopSound = loop;
-	alSourcei(p_Source, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
-}
-
-bool OpenALSoundComponent::IsPlaying() const
-{
-	ALint state;
-	alGetSourcei(p_Source, AL_SOURCE_STATE, &state);
-	return (state == AL_PLAYING);
-}
-
-bool OpenALSoundComponent::IsPaused() const
-{
-	ALint state;
-	alGetSourcei(p_Source, AL_SOURCE_STATE, &state);
-	return (state == AL_PAUSED);
-}
-
-bool OpenALSoundComponent::IsStopped() const
-{
-	ALint state;
-	alGetSourcei(p_Source, AL_SOURCE_STATE, &state);
-	return (state == AL_STOPPED);
-}
+#include <entt/entt.hpp>
+#include "../../SOUNDS/ESSENTIALS/OpenALSound.h"
+#include "../../RESOURCES/AssetManager.h"
 
 void OpenALSoundComponent::CreateLuaOpenALSoundComponentBind(sol::state& lua)
 {
@@ -112,29 +10,67 @@ void OpenALSoundComponent::CreateLuaOpenALSoundComponentBind(sol::state& lua)
 		"type_id", &entt::type_hash<OpenALSoundComponent>::value,
 		sol::call_constructor,
 		sol::factories(
-			[&]() {
-				return OpenALSoundComponent();
+			// Make sound component with empty sound
+			[]{ return OpenALSoundComponent{ .pSound = std::make_shared<OpenALSound>() }; },
+			[&](const std::string& sSoundName) 
+			{
+				auto& assetManager = MAIN_REGISTRY().GetAssetManager();
+				ALuint bufferToPlay = assetManager.GetSoundEffect(sSoundName);
+				OpenALSoundComponent soundComponent{ .pSound = std::make_shared<OpenALSound>() };
+				if (bufferToPlay == 0)
+				{
+					LOG_ERROR("Failed to set OpenAL sound. [{}] is invalid.", sSoundName);
+					return soundComponent;
+				}
+
+				soundComponent.pSound->SetBuffer(bufferToPlay);
+				return soundComponent;
 			}
 		),
 
 		// Playback control
-		"Play", [](OpenALSoundComponent& self, const std::string& name) {
-			self.Play(name);
+		"Play", sol::overload(
+		[](OpenALSoundComponent& self) 
+		{ 
+			if (!self.pSound->IsBufferValid())
+			{
+				LOG_ERROR("Failed to play sound. Buffer is not valid.");
+				return;
+			}
+
+			self.pSound->Play(); 
 		},
-		"Stop", &OpenALSoundComponent::Stop,
-		"Pause", &OpenALSoundComponent::Pause,
-		"Resume", &OpenALSoundComponent::Resume,
+		[&](OpenALSoundComponent& self, const std::string& sSoundName) 
+		{
+			auto& assetManager = MAIN_REGISTRY().GetAssetManager();
+			ALuint bufferToPlay = assetManager.GetSoundEffect(sSoundName);
+			if (bufferToPlay == 0)
+			{
+				LOG_ERROR("Failed to play sound. [{}] is invalid.", sSoundName);
+				return;
+			}
+
+			if (!self.pSound->IsBufferSame(bufferToPlay))
+			{
+				self.pSound->SetBuffer(bufferToPlay);
+			}
+
+			self.pSound->Play();
+		}),
+		"Stop", [](OpenALSoundComponent& self) { self.pSound->Stop(); },
+		"Pause", [](OpenALSoundComponent& self) { self.pSound->Pause(); },
+		"Resume", [](OpenALSoundComponent& self) { self.pSound->Resume(); },
 
 		// Property setters
-		"SetPitch", &OpenALSoundComponent::SetPitch,
-		"SetGain", &OpenALSoundComponent::SetGain,
-		"SetPosition", &OpenALSoundComponent::SetPosition,
-		"SetVelocity", &OpenALSoundComponent::SetVelocity,
-		"SetLooping", &OpenALSoundComponent::SetLooping,
+		"SetPitch", [](OpenALSoundComponent& self, float pitch) { self.pSound->SetPitch(pitch); },
+		"SetGain", [](OpenALSoundComponent& self, float gain) { self.pSound->SetGain(gain); },
+		"SetPosition", [](OpenALSoundComponent& self, float x, float y, float z) { self.pSound->SetPosition(x, y, z); },
+		"SetVelocity", [](OpenALSoundComponent& self, float x, float y, float z) { self.pSound->SetVelocity(x, y, z); },
+		"SetLooping", [](OpenALSoundComponent& self, bool bLooping) { self.pSound->SetLooping(bLooping); },
 
 		// State queries
-		"IsPlaying", &OpenALSoundComponent::IsPlaying,
-		"IsPaused", &OpenALSoundComponent::IsPaused,
-		"IsStopped", &OpenALSoundComponent::IsStopped
+		"IsPlaying", []( OpenALSoundComponent& self ) { return self.pSound->IsPlaying(); },
+		"IsPaused", [](OpenALSoundComponent& self) { return self.pSound->IsPaused(); },
+		"IsStopped", [](OpenALSoundComponent& self) { return self.pSound->IsStopped(); }
 	);
 }

--- a/GAMEENGINE/ENGINE/ECS/COMPONENTS/OpenALSoundComponent.h
+++ b/GAMEENGINE/ENGINE/ECS/COMPONENTS/OpenALSoundComponent.h
@@ -1,43 +1,12 @@
 #pragma once
-
 #include <sol/sol.hpp>
-#include <entt/entt.hpp>
-#include <AL/al.h>
 #include <string>
 
-#include "../MainRegistry.h"
-#include "../../LOGGER/log.h"
-
-class OpenALSoundComponent
+struct OpenALSoundComponent
 {
-public:
-	OpenALSoundComponent();
-	~OpenALSoundComponent();
-
-    void Play(std::string name);
-    void Stop();
-    void Pause();
-    void Resume();
-
-    void SetPitch(float pitch);
-    void SetGain(float gain);
-    void SetPosition(float x, float y, float z);
-    void SetVelocity(float x, float y, float z);
-    void SetLooping(bool loop);
-
-    bool IsPlaying() const;
-    bool IsPaused() const;
-    bool IsStopped() const;
+    /* OpenAL sound to play. */
+    std::shared_ptr<class OpenALSound> pSound{ nullptr };
 
     static void CreateLuaOpenALSoundComponentBind(sol::state& lua);
-
-private:
-    ALuint p_Source;
-    float p_Pitch;
-    float p_Gain;
-    float p_Position[3];
-    float p_Velocity[3];
-    bool p_LoopSound;
-    ALuint p_Buffer;
 };
 

--- a/GAMEENGINE/ENGINE/SOUNDS/ESSENTIALS/OpenALSound.cpp
+++ b/GAMEENGINE/ENGINE/SOUNDS/ESSENTIALS/OpenALSound.cpp
@@ -1,0 +1,166 @@
+#include "OpenALSound.h"
+#include <entt/entt.hpp>
+#include "../../LOGGER/log.h"
+
+OpenALSound::OpenALSound()
+	: OpenALSound(0)
+{
+
+}
+
+OpenALSound::OpenALSound(const ALuint buffer)
+	: m_Source{ 0 }
+	, m_Buffer{ buffer }
+	, m_Pitch{ 1.f }
+	, m_Gain{ 1.f }
+	, m_Position{ 0.f,0.f,0.f }
+	, m_Velocity{ 0.f, 0.f, 0.f }
+	, m_LoopSound{ false }
+{
+	alGenSources(1, &m_Source);
+	alSourcef(m_Source, AL_PITCH, m_Pitch);
+	alSourcef(m_Source, AL_GAIN, m_Gain);
+	alSource3f(m_Source, AL_POSITION, m_Position[0], m_Position[1], m_Position[2]);
+	alSource3f(m_Source, AL_VELOCITY, m_Velocity[0], m_Velocity[1], m_Velocity[2]);
+	alSourcei(m_Source, AL_LOOPING, m_LoopSound);
+}
+
+OpenALSound::~OpenALSound()
+{
+	Stop();
+	alDeleteSources(1, &m_Source);
+}
+
+void OpenALSound::Play() const
+{
+	if (m_Buffer == 0)
+	{
+		LOG_WARN("Failed to play sound. Buffer has not been set.");
+		return;
+	}
+
+	alSourcePlay(m_Source);
+}
+
+void OpenALSound::Stop() const
+{
+	alSourceStop(m_Source);
+}
+
+void OpenALSound::Pause() const
+{
+	alSourcePause(m_Source);
+}
+
+void OpenALSound::Resume() const
+{
+	alSourcePlay(m_Source);
+}
+
+void OpenALSound::SetBuffer(const ALuint buffer)
+{
+	if (IsPlaying())
+	{
+		Stop();
+	}
+
+	m_Buffer = buffer;
+	alSourcei(m_Source, AL_BUFFER, static_cast<ALint>(m_Buffer));
+}
+
+void OpenALSound::SetPitch(float pitch)
+{
+	m_Pitch = pitch;
+	alSourcef(m_Source, AL_PITCH, m_Pitch);
+}
+
+void OpenALSound::SetGain(float gain)
+{
+	m_Gain = gain;
+	alSourcef(m_Source, AL_GAIN, m_Gain);
+}
+
+void OpenALSound::SetPosition(float x, float y, float z)
+{
+	m_Position[0] = x;
+	m_Position[1] = y;
+	m_Position[2] = z;
+	alSource3f(m_Source, AL_POSITION, x, y, z);
+}
+
+void OpenALSound::SetVelocity(float x, float y, float z)
+{
+	m_Velocity[0] = x;
+	m_Velocity[1] = y;
+	m_Velocity[2] = z;
+	alSource3f(m_Source, AL_VELOCITY, x, y, z);
+}
+
+void OpenALSound::SetLooping(bool loop)
+{
+	m_LoopSound = loop;
+	alSourcei(m_Source, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
+}
+
+bool OpenALSound::IsPlaying() const
+{
+	ALint state;
+	alGetSourcei(m_Source, AL_SOURCE_STATE, &state);
+	return (state == AL_PLAYING);
+}
+
+bool OpenALSound::IsPaused() const
+{
+	ALint state;
+	alGetSourcei(m_Source, AL_SOURCE_STATE, &state);
+	return (state == AL_PAUSED);
+}
+
+bool OpenALSound::IsStopped() const
+{
+	ALint state;
+	alGetSourcei(m_Source, AL_SOURCE_STATE, &state);
+	return (state == AL_STOPPED);
+}
+
+bool OpenALSound::IsBufferValid() const
+{
+	return m_Buffer != 0;
+}
+
+bool OpenALSound::IsBufferSame(const ALuint buffer) const
+{
+	return m_Buffer == buffer;
+}
+
+void OpenALSound::CreateLuaOpenALSoundBind(sol::state& lua)
+{
+	lua.new_usertype<OpenALSound>(
+		"OpenALSound",
+		"type_id", &entt::type_hash<OpenALSound>::value,
+		sol::call_constructor,
+		sol::factories(
+			[&]() {
+				return OpenALSound();
+			}
+		),
+
+		// Playback control
+		"Play", &OpenALSound::Play,
+		"Stop", &OpenALSound::Stop,
+		"Pause", &OpenALSound::Pause,
+		"Resume", &OpenALSound::Resume,
+
+		// Property setters
+		"SetPitch", &OpenALSound::SetPitch,
+		"SetGain", &OpenALSound::SetGain,
+		"SetPosition", &OpenALSound::SetPosition,
+		"SetVelocity", &OpenALSound::SetVelocity,
+		"SetLooping", &OpenALSound::SetLooping,
+
+		// State queries
+		"IsPlaying", &OpenALSound::IsPlaying,
+		"IsPaused", &OpenALSound::IsPaused,
+		"IsStopped", &OpenALSound::IsStopped
+	);
+}

--- a/GAMEENGINE/ENGINE/SOUNDS/ESSENTIALS/OpenALSound.h
+++ b/GAMEENGINE/ENGINE/SOUNDS/ESSENTIALS/OpenALSound.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <sol/sol.hpp>
+#include <AL/al.h>
+#include <string>
+
+class OpenALSound
+{
+public:
+	OpenALSound();
+	OpenALSound(const ALuint buffer);
+	~OpenALSound();
+
+	void Play() const;
+	void Stop() const;
+	void Pause() const;
+	void Resume() const;
+
+	void SetBuffer(const ALuint buffer);
+	void SetPitch(float pitch);
+	void SetGain(float gain);
+	void SetPosition(float x, float y, float z);
+	void SetVelocity(float x, float y, float z);
+	void SetLooping(bool loop);
+
+	bool IsPlaying() const;
+	bool IsPaused() const;
+	bool IsStopped() const;
+	bool IsBufferValid() const;
+	bool IsBufferSame(const ALuint buffer) const;
+
+	static void CreateLuaOpenALSoundBind(sol::state& lua);
+
+private:
+	ALuint m_Source;
+	ALuint m_Buffer;
+	float m_Pitch;
+	float m_Gain;
+	float m_Position[3];
+	float m_Velocity[3];
+	bool m_LoopSound;
+};

--- a/Project1.vcxproj
+++ b/Project1.vcxproj
@@ -294,6 +294,7 @@
     <Image Include="ASSETS\TILEDMAP\FireBoyWaterGirl\FBWGTileset.png" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="GAMEENGINE\ENGINE\SOUNDS\ESSENTIALS\OpenALSound.cpp" />
     <ClCompile Include="SRC\EDITOR\DISPLAYS\AssetDisplay.cpp" />
     <ClCompile Include="SRC\EDITOR\SYSTEMS\GridSystem.cpp" />
     <ClCompile Include="SRC\EDITOR\DISPLAYS\LogDisplay.cpp" />
@@ -311,6 +312,7 @@
     <ClCompile Include="SRC\EDITOR\DISPLAYS\TilemapDisplay.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="GAMEENGINE\ENGINE\SOUNDS\ESSENTIALS\OpenALSound.h" />
     <ClInclude Include="SRC\EDITOR\DISPLAYS\AssetDisplay.h" />
     <ClInclude Include="SRC\EDITOR\SYSTEMS\GridSystem.h" />
     <ClInclude Include="SRC\EDITOR\DISPLAYS\LogDisplay.h" />

--- a/Project1.vcxproj.filters
+++ b/Project1.vcxproj.filters
@@ -134,6 +134,9 @@
     <ClCompile Include="SRC\EDITOR\DISPLAYS\AssetDisplay.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GAMEENGINE\ENGINE\SOUNDS\ESSENTIALS\OpenALSound.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SRC\Application.h">
@@ -194,6 +197,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SRC\EDITOR\UTILITIES\EditorUtilities.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GAMEENGINE\ENGINE\SOUNDS\ESSENTIALS\OpenALSound.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
* Created an OpenALSound class.
* This class controls the sound and it is completely separate from the component, asset manager etc.
* Separated the concerns for the sounds themselves and the component.
* Adjusted the component to use a shared_ptr<OpenALSound> with wrappers around the functions.
* Now the Dtor will only be called once the entity releases it's OpenALComponent.